### PR TITLE
Update template.yaml

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -5,7 +5,7 @@ Description: Generic Webhook to EventBridge event bus
 Globals:
   Function:
     Timeout: 29
-    Runtime: nodejs12.x
+    Runtime: nodejs18.x
     Tracing: Active
 
 Metadata:


### PR DESCRIPTION
Updated runtime to nodejs18 based on the following deployment error:

Resource handler returned message: "The runtime parameter of nodejs12.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs18.x) while creating or updating functions."